### PR TITLE
Fix some TGF items not working in Special Stage Challenge maps

### DIFF
--- a/Lua/TGFMonitors/LUA_TBXI.txt
+++ b/Lua/TGFMonitors/LUA_TBXI.txt
@@ -15,7 +15,7 @@ end
 
 addHook("MapThingSpawn", RM_TGFPowerUpSetup, MT_TGFBOX_INVIN_SPECIAL)
 addHook("MobjFuse", RM_TGFMonitorFuseThink, MT_TGFBOX_INVIN_SPECIAL)
-addHook("MobjDeath", RM_TGFMonitorDeath, MT_TGFBOX_INVIN_SPECIAL)
+addHook("MobjDeath", RM_TGFPowerUpDeath, MT_TGFBOX_INVIN_SPECIAL)
 
 mobjinfo[MT_TGFBOX_INVIN_SPECIAL] = {
 	//$Name TGF Invincibility (Power-Up)

--- a/Lua/TGFMonitors/LUA_TBXR.txt
+++ b/Lua/TGFMonitors/LUA_TBXR.txt
@@ -99,7 +99,7 @@ addHook("TouchSpecial", function(special, toucher)
 	end
 end, MT_TGFBOX_RING_SPECIAL)
 
-addHook("MobjDeath", RM_TGFMonitorDeath, MT_TGFBOX_RING_SPECIAL)
+addHook("MobjDeath", RM_TGFPowerUpDeath, MT_TGFBOX_RING_SPECIAL)
 
 mobjinfo[MT_TGFBOX_RING_SPECIAL] = {
 	--$Name TGF Super Ring (5 Rings) (Power-Up)

--- a/Lua/TGFMonitors/LUA_TBXR.txt
+++ b/Lua/TGFMonitors/LUA_TBXR.txt
@@ -88,8 +88,14 @@ addHook("TouchSpecial", function(special, toucher)
 	if not (special and special.valid and toucher and toucher.valid) then return end
 	if not (toucher.player and toucher.player.valid) then return end
 	
-	if G_IsSpecialStage(gamemap) then
+	local isOldNights = mapheaderinfo[gamemap] and mapheaderinfo[gamemap].oldnights and not G_IsSpecialStage()
+	
+	if G_IsSpecialStage(gamemap) or isOldNights then
 		toucher.player.spheres = $+5
+	end
+	
+	if mapheaderinfo[gamemap].oldspecial or isOldNights then
+		total_spheres = $+5
 	end
 end, MT_TGFBOX_RING_SPECIAL)
 

--- a/Lua/TGFMonitors/LUA_TBXS.txt
+++ b/Lua/TGFMonitors/LUA_TBXS.txt
@@ -54,7 +54,7 @@ states[S_TGFBOX_SHOES_BREAK] =	{SPR_TBXX,	A,	0,	RM_TGFSuperSneakers,	0,	0,	S_TGF
 
 addHook("MapThingSpawn", RM_TGFPowerUpSetup, MT_TGFBOX_SHOES_SPECIAL)
 addHook("MobjFuse", RM_TGFMonitorFuseThink, MT_TGFBOX_SHOES_SPECIAL)
-addHook("MobjDeath", RM_TGFMonitorDeath, MT_TGFBOX_SHOES_SPECIAL)
+addHook("MobjDeath", RM_TGFPowerUpDeath, MT_TGFBOX_SHOES_SPECIAL)
 
 mobjinfo[MT_TGFBOX_SHOES_SPECIAL] = {
 	--$Name TGF Super Sneakers (Power-Up)
@@ -68,7 +68,6 @@ mobjinfo[MT_TGFBOX_SHOES_SPECIAL] = {
 	doomednum = 515,
 	spawnstate = S_TGFBOX_SHOES_SPECIAL_IDLE,
 	spawnhealth = 1,
-	reactiontime = 5,
 	painstate = S_TGFBOX_SHOES_SPECIAL_IDLE,
 	deathstate = S_TGFBOX_SHOES_SPECIAL_DEATH,
 	deathsound = sfx_tgfbng, -- Replace sfx_tgfbng if you decide to use something else

--- a/Lua/TGFMonitors/LUA_TBXT.txt
+++ b/Lua/TGFMonitors/LUA_TBXT.txt
@@ -12,8 +12,8 @@ freeslot(
 function A_GiveTime(actor, var1, var2)
 	if not (actor and actor.valid) then return end
 	
-	-- Do not give the player more time if they are outside of a Special Stage
-	if not G_IsSpecialStage(gamemap) then
+	-- Do not give the player more time if they are outside of a Special Stage or NiGHTS stage
+	if not (G_IsSpecialStage(gamemap) or (mapheaderinfo[gamemap] and mapheaderinfo[gamemap].oldspecial) or (maptol & TOL_NIGHTS)) then
 		S_StopSound(actor)
 		S_StartSound(actor, sfx_lose)
 		return

--- a/Lua/TGFMonitors/LUA_TBXT.txt
+++ b/Lua/TGFMonitors/LUA_TBXT.txt
@@ -27,9 +27,9 @@ function A_GiveTime(actor, var1, var2)
 		else
 			target.player.nightstime = $+(15*TICRATE)
 		end
+		
+		S_StartSound(target, sfx_tgfbng) -- Replace sfx_tgfbng if you decide to use something else
 	end
-	
-	S_StartSound(actor, sfx_tgfbng) -- Replace sfx_tgfbng if you decide to use something else
 end
 
 local function RM_TGFGiveTime(actor, var1, var2)
@@ -39,7 +39,7 @@ end
 
 addHook("MapThingSpawn", RM_TGFPowerUpSetup, MT_TGFBOX_TIME_SPECIAL)
 addHook("MobjFuse", RM_TGFMonitorFuseThink, MT_TGFBOX_TIME_SPECIAL)
-addHook("MobjDeath", RM_TGFMonitorDeath, MT_TGFBOX_TIME_SPECIAL)
+addHook("MobjDeath", RM_TGFPowerUpDeath, MT_TGFBOX_TIME_SPECIAL)
 
 mobjinfo[MT_TGFBOX_TIME_SPECIAL] = {
 	--$Name TGF Time Bonus (Power-Up)

--- a/Lua/old_spec_and_nights.lua
+++ b/Lua/old_spec_and_nights.lua
@@ -3,7 +3,7 @@
 
 local changed_objs = false
 local loaded_hud = false
-local total_spheres = 0
+rawset(_G, "total_spheres", 0) -- Turned into a global variable so the TGF ring item can use it -- MIDIMan
 
 -- addHook("MapLoad", function(id)
 table.insert(preMapLoadHooks, function()


### PR DESCRIPTION
This PR makes the ring and time TGF power-ups work in maps with the `OldSpecial` parameter set. It also fixes a bug where their pickup sound(s) would play twice, making them louder than intended.