### PR TITLE
Fix Attraction Shield not working in many levels

### DIFF
--- a/Lua/TPEra/TPEra.Rings.lua
+++ b/Lua/TPEra/TPEra.Rings.lua
@@ -234,9 +234,9 @@ local function lua_AttractA(source, dest) -- Direct Pull ala Sonic Adventure, cu
 		speedmul = P_AproxDistance(dest.momx, dest.momy) + FixedMul(source.info.speed, source.scale)
 
 
-		ource.momx = FixedMul(FixedDiv(tx - source.x, dist), speedmul)
-		ource.momy = FixedMul(FixedDiv(ty - source.y, dist), speedmul)
-		ource.momz = FixedMul(FixedDiv(tz - source.z, dist), speedmul)
+		source.momx = FixedMul(FixedDiv(tx - source.x, dist), speedmul)
+		source.momy = FixedMul(FixedDiv(ty - source.y, dist), speedmul)
+		source.momz = FixedMul(FixedDiv(tz - source.z, dist), speedmul)
 
 		-- Instead of just unsetting NOCLIP like an idiot, let's check the distance to our target.	
 		ndist = P_AproxDistance(P_AproxDistance(tx - (source.x+source.momx), 


### PR DESCRIPTION
This PR fixes a bug where attempting to attract rings with the Attraction Shield would print errors to the console instead of attracting them. This was caused by my `tpera-valid-checks` branch PR, where I accidentally replaced `source` with `ource` in the ring attraction code in `TPEra.Rings.lua`. My bad!